### PR TITLE
Populated order summary list and added additional, basic card validation

### DIFF
--- a/MiniPosSystem/Forms/frmPayment.cs
+++ b/MiniPosSystem/Forms/frmPayment.cs
@@ -41,19 +41,42 @@ namespace MiniPosSystem
             grpCashPayment.Visible = false;
         }
 
+
+        /// <summary>
+        /// Adds current order to the database if all input is valid
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void BtnSubmit_Click(object sender, EventArgs e)
         {
-            if (radCard.Checked && IsValidCard(txtCardNumber))
+            if (radCard.Checked && IsValidCardInfo(txtCardNumber))
+            {
                 AddNewCard();
-
-            else if(radCash.Checked && IsValidInput(txtCashGiven))
+                FinalizePayment();
+            }
+            if (radCash.Checked && IsValidCashInput(txtCashGiven))
+            {
                 AddCashPayment();
+                FinalizePayment();
+            }               
+        }
 
+
+        /// <summary>
+        /// Adds the current order to the database and 
+        /// displays the corresponding receipt to the user
+        /// </summary>
+        private void FinalizePayment()
+        {
             TransactionsDB.AddTransaction(order);
             ShowReceipt();
             ActiveForm.Close();
         }
 
+
+        /// <summary>
+        /// Adds current cash payment information to the database
+        /// </summary>
         private void AddCashPayment()
         {
             decimal cashGiven = (Convert.ToDecimal(txtCashGiven.Text));
@@ -66,6 +89,10 @@ namespace MiniPosSystem
             txtChange.Text = $"{ cashGiven - order.Price }";
         }
 
+
+        /// <summary>
+        /// Displays form consisting of the current order's information
+        /// </summary>
         private void ShowReceipt()
         {
             Form receipt = new frmReceipt(order);
@@ -74,39 +101,67 @@ namespace MiniPosSystem
 
 
         /// <summary>
-        /// Returns true if valid information is given
+        /// Returns true if valid card information is supplied
         /// </summary>
         /// <returns></returns>
-        private Boolean IsValidCard(TextBox input)
+        private Boolean IsValidCardInfo(TextBox cardNumber)
         {
+            string cardNumString = cardNumber.Text.Replace("-", string.Empty);
             try
             {
-                if ( string.IsNullOrWhiteSpace(input.Text) ||
-                     string.IsNullOrWhiteSpace(input.Text) ||
+                // if not 16 digits
+                if (cardNumString.Trim().Length < 16 ||
+                    cardNumString.Trim().Length > 16)
+                {
+                    DisplayErrorMessage("Please enter valid card information ( ex. 5336-4349-6250-1234 )");
+                    return false;
+                }
+                // if every entry is not completed
+                if ( string.IsNullOrWhiteSpace(cardNumber.Text) ||
+                     string.IsNullOrWhiteSpace(txtCardHolder.Text) ||
                     cboCardType.SelectedItem == null)
                 {
-                    btnSubmit.Enabled = false;
-                    MessageBox.Show("Please fill out every entry");
+                    DisplayErrorMessage("Please complete every entry");
+                    return false;
+                }
+                // if card number input is not a number
+                ulong value;
+                if (!ulong.TryParse(cardNumString, out value))
+                {
+                    DisplayErrorMessage("Please enter a valid card number");
                     return false;
                 }
             }
             catch (FormatException)
             {
-                //MessageBox.Show("Please enter valid information");
+                DisplayErrorMessage("Please enter valid information");
                 return false;
             }
-
-            btnSubmit.Enabled = true;
             return true;
         }
 
 
         /// <summary>
+        /// Displays appropriate error message to user
+        /// </summary>
+        /// <param name="errorMessage"></param>
+        /// <returns></returns>
+        private bool DisplayErrorMessage(string errorMessage)
+        {
+            btnSubmit.Enabled = false;
+            MessageBox.Show(errorMessage);
+            btnSubmit.Enabled = true;
+            return false;
+        }
+
+
+        /// <summary>
         /// Returns false if no input is given or numbers are not 
-        /// present.
+        /// present. Enables/disables button accordingly for visual
+        /// purposes.
         /// </summary>
         /// <returns>False if not valid numbers</returns>
-        private Boolean IsValidInput(TextBox input)
+        private Boolean IsValidCashInput(TextBox input)
         {
             try
             {
@@ -114,42 +169,43 @@ namespace MiniPosSystem
                 {
                     btnSubmit.Enabled = false;
                     MessageBox.Show("Please enter a cash amount");
+                    btnSubmit.Enabled = true;
                     return false;
                 }
                 if (Convert.ToDecimal(txtCashGiven.Text) < order.Price)
                 {
                     btnSubmit.Enabled = false;
                     MessageBox.Show("Please pay the bill in its entirety!");
+                    btnSubmit.Enabled = true;
                     return false;
                 }
             }
             catch (FormatException)
             {
+                btnSubmit.Enabled = false;
                 MessageBox.Show("Please enter numbers in decimal format (ex. 8, 8.00, 8.50)");
+                btnSubmit.Enabled = true;
                 return false;
             }
-            
             return true;
         }
 
+
+        /// <summary>
+        /// Adds current card payment to database
+        /// </summary>
         private void AddNewCard()
         {
-            try
+            PaymentInfo card = new PaymentInfo()
             {
-                PaymentInfo card = new PaymentInfo()
-                {
-                    CardNumber = Convert.ToUInt64(txtCardNumber.Text),
-                    NameOnCard = txtCardHolder.Text,
-                    CardType = cboCardType.SelectedItem.ToString()
-                };
-                PaymentInfoDB.AddPayment(card);
-                order.PaymentInfo = card;
-            }
-            catch (FormatException)
-            {
-                btnSubmit.Enabled = false;
-                MessageBox.Show("Please enter valid information");
-            }
+                CardNumber = Convert.ToUInt64(txtCardNumber.Text.Replace("-", string.Empty)),
+                NameOnCard = txtCardHolder.Text,
+                CardType = cboCardType.SelectedItem.ToString()
+            };
+            PaymentInfoDB.AddPayment(card);
+            order.PaymentInfo = card;
         }
+
+
     }
 }

--- a/MiniPosSystem/Forms/frmPayment.cs
+++ b/MiniPosSystem/Forms/frmPayment.cs
@@ -56,7 +56,7 @@ namespace MiniPosSystem
             }
             if (radCash.Checked && IsValidCashInput(txtCashGiven))
             {
-                AddCashPayment();
+                AddCashPayment(txtCashGiven.Text.Replace("$", string.Empty));
                 FinalizePayment();
             }               
         }
@@ -77,9 +77,9 @@ namespace MiniPosSystem
         /// <summary>
         /// Adds current cash payment information to the database
         /// </summary>
-        private void AddCashPayment()
+        private void AddCashPayment(string input)
         {
-            decimal cashGiven = (Convert.ToDecimal(txtCashGiven.Text));
+            decimal cashGiven = (Convert.ToDecimal(input));
             PaymentInfo cashPayment = new PaymentInfo()
             {
                 CardNumber = 0,
@@ -162,28 +162,23 @@ namespace MiniPosSystem
         /// <returns>False if not valid numbers</returns>
         private Boolean IsValidCashInput(TextBox input)
         {
+            string cashInput = txtCashGiven.Text.Replace("$", string.Empty);
             try
             {
-                if (string.IsNullOrWhiteSpace(input.Text))
+                if (string.IsNullOrWhiteSpace(cashInput))
                 {
-                    btnSubmit.Enabled = false;
-                    MessageBox.Show("Please enter a cash amount");
-                    btnSubmit.Enabled = true;
+                    DisplayErrorMessage("Please enter a cash amount");
                     return false;
                 }
-                if (Convert.ToDecimal(txtCashGiven.Text) < order.Price)
+                if (Convert.ToDecimal(cashInput) < order.Price)
                 {
-                    btnSubmit.Enabled = false;
-                    MessageBox.Show("Please pay the bill in its entirety!");
-                    btnSubmit.Enabled = true;
+                    DisplayErrorMessage("Please pay the bill in its entirety!");
                     return false;
                 }
             }
             catch (FormatException)
             {
-                btnSubmit.Enabled = false;
-                MessageBox.Show("Please enter numbers in decimal format (ex. 8, 8.00, 8.50)");
-                btnSubmit.Enabled = true;
+                DisplayErrorMessage("Please enter numbers in decimal format (ex. 8, 8.00, 8.50)");
                 return false;
             }
             return true;

--- a/MiniPosSystem/Forms/frmPayment.cs
+++ b/MiniPosSystem/Forms/frmPayment.cs
@@ -146,12 +146,11 @@ namespace MiniPosSystem
         /// </summary>
         /// <param name="errorMessage"></param>
         /// <returns></returns>
-        private bool DisplayErrorMessage(string errorMessage)
+        private void DisplayErrorMessage(string errorMessage)
         {
             btnSubmit.Enabled = false;
             MessageBox.Show(errorMessage);
             btnSubmit.Enabled = true;
-            return false;
         }
 
 

--- a/MiniPosSystem/Forms/frmReceipt.Designer.cs
+++ b/MiniPosSystem/Forms/frmReceipt.Designer.cs
@@ -34,7 +34,7 @@
             this.lblServer = new System.Windows.Forms.Label();
             this.lblTime = new System.Windows.Forms.Label();
             this.lblDate = new System.Windows.Forms.Label();
-            this.listBox1 = new System.Windows.Forms.ListBox();
+            this.lstOrderInfo = new System.Windows.Forms.ListBox();
             this.lblChangeCard = new System.Windows.Forms.Label();
             this.lblTotal = new System.Windows.Forms.Label();
             this.lblCardNameCash = new System.Windows.Forms.Label();
@@ -46,138 +46,151 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(192, 86);
+            this.label1.Location = new System.Drawing.Point(144, 70);
+            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(155, 17);
+            this.label1.Size = new System.Drawing.Size(120, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Lakewood, Washington";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(204, 66);
+            this.label2.Location = new System.Drawing.Point(153, 54);
+            this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(123, 17);
+            this.label2.Size = new System.Drawing.Size(95, 13);
             this.label2.TabIndex = 1;
             this.label2.Text = "2513 Wallabe Ave";
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(211, 44);
+            this.label3.Location = new System.Drawing.Point(158, 36);
+            this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(106, 17);
+            this.label3.Size = new System.Drawing.Size(79, 13);
             this.label3.TabIndex = 2;
             this.label3.Text = "Our Restaurant";
             // 
             // lblServer
             // 
             this.lblServer.AutoSize = true;
-            this.lblServer.Location = new System.Drawing.Point(72, 124);
+            this.lblServer.Location = new System.Drawing.Point(54, 101);
+            this.lblServer.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblServer.Name = "lblServer";
-            this.lblServer.Size = new System.Drawing.Size(50, 17);
+            this.lblServer.Size = new System.Drawing.Size(38, 13);
             this.lblServer.TabIndex = 3;
             this.lblServer.Text = "Server";
             // 
             // lblTime
             // 
             this.lblTime.AutoSize = true;
-            this.lblTime.Location = new System.Drawing.Point(378, 170);
+            this.lblTime.Location = new System.Drawing.Point(284, 138);
+            this.lblTime.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblTime.Name = "lblTime";
-            this.lblTime.Size = new System.Drawing.Size(39, 17);
+            this.lblTime.Size = new System.Drawing.Size(30, 13);
             this.lblTime.TabIndex = 4;
             this.lblTime.Text = "Time";
             // 
             // lblDate
             // 
             this.lblDate.AutoSize = true;
-            this.lblDate.Location = new System.Drawing.Point(378, 132);
+            this.lblDate.Location = new System.Drawing.Point(284, 107);
+            this.lblDate.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblDate.Name = "lblDate";
-            this.lblDate.Size = new System.Drawing.Size(38, 17);
+            this.lblDate.Size = new System.Drawing.Size(30, 13);
             this.lblDate.TabIndex = 5;
             this.lblDate.Text = "Date";
             // 
-            // listBox1
+            // lstOrderInfo
             // 
-            this.listBox1.FormattingEnabled = true;
-            this.listBox1.ItemHeight = 16;
-            this.listBox1.Location = new System.Drawing.Point(27, 215);
-            this.listBox1.Name = "listBox1";
-            this.listBox1.Size = new System.Drawing.Size(484, 180);
-            this.listBox1.TabIndex = 6;
+            this.lstOrderInfo.FormattingEnabled = true;
+            this.lstOrderInfo.Location = new System.Drawing.Point(20, 175);
+            this.lstOrderInfo.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.lstOrderInfo.Name = "lstOrderInfo";
+            this.lstOrderInfo.Size = new System.Drawing.Size(364, 147);
+            this.lstOrderInfo.TabIndex = 6;
             // 
             // lblChangeCard
             // 
             this.lblChangeCard.AutoSize = true;
-            this.lblChangeCard.Location = new System.Drawing.Point(72, 479);
+            this.lblChangeCard.Location = new System.Drawing.Point(54, 389);
+            this.lblChangeCard.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblChangeCard.Name = "lblChangeCard";
-            this.lblChangeCard.Size = new System.Drawing.Size(91, 17);
+            this.lblChangeCard.Size = new System.Drawing.Size(71, 13);
             this.lblChangeCard.TabIndex = 7;
             this.lblChangeCard.Text = "Change/Card";
             // 
             // lblTotal
             // 
             this.lblTotal.AutoSize = true;
-            this.lblTotal.Location = new System.Drawing.Point(72, 420);
+            this.lblTotal.Location = new System.Drawing.Point(54, 341);
+            this.lblTotal.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblTotal.Name = "lblTotal";
-            this.lblTotal.Size = new System.Drawing.Size(40, 17);
+            this.lblTotal.Size = new System.Drawing.Size(31, 13);
             this.lblTotal.TabIndex = 8;
             this.lblTotal.Text = "Total";
             // 
             // lblCardNameCash
             // 
             this.lblCardNameCash.AutoSize = true;
-            this.lblCardNameCash.Location = new System.Drawing.Point(72, 450);
+            this.lblCardNameCash.Location = new System.Drawing.Point(54, 366);
+            this.lblCardNameCash.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblCardNameCash.Name = "lblCardNameCash";
-            this.lblCardNameCash.Size = new System.Drawing.Size(169, 17);
+            this.lblCardNameCash.Size = new System.Drawing.Size(131, 13);
             this.lblCardNameCash.TabIndex = 9;
             this.lblCardNameCash.Text = "Name on card/cash given";
             // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(123, 524);
+            this.label4.Location = new System.Drawing.Point(92, 426);
+            this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(273, 17);
+            this.label4.Size = new System.Drawing.Size(207, 13);
             this.label4.TabIndex = 10;
             this.label4.Text = "Let us know about your dining experience!";
             // 
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(42, 544);
+            this.label5.Location = new System.Drawing.Point(32, 442);
+            this.label5.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(461, 17);
+            this.label5.Size = new System.Drawing.Size(342, 13);
             this.label5.TabIndex = 11;
             this.label5.Text = "Email us directly at ourRestaurant@mail.com or call us at 222-123-4567";
             // 
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(219, 565);
+            this.label6.Location = new System.Drawing.Point(164, 459);
+            this.label6.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(98, 17);
+            this.label6.Size = new System.Drawing.Size(75, 13);
             this.label6.TabIndex = 12;
             this.label6.Text = "See you soon!";
             // 
             // frmReceipt
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(548, 629);
+            this.ClientSize = new System.Drawing.Size(411, 511);
             this.Controls.Add(this.label6);
             this.Controls.Add(this.label5);
             this.Controls.Add(this.label4);
             this.Controls.Add(this.lblCardNameCash);
             this.Controls.Add(this.lblTotal);
             this.Controls.Add(this.lblChangeCard);
-            this.Controls.Add(this.listBox1);
+            this.Controls.Add(this.lstOrderInfo);
             this.Controls.Add(this.lblDate);
             this.Controls.Add(this.lblTime);
             this.Controls.Add(this.lblServer);
             this.Controls.Add(this.label3);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.label1);
+            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.Name = "frmReceipt";
             this.Text = "frmReceipt";
             this.Load += new System.EventHandler(this.FrmReceipt_Load);
@@ -194,7 +207,7 @@
         private System.Windows.Forms.Label lblServer;
         private System.Windows.Forms.Label lblTime;
         private System.Windows.Forms.Label lblDate;
-        private System.Windows.Forms.ListBox listBox1;
+        private System.Windows.Forms.ListBox lstOrderInfo;
         private System.Windows.Forms.Label lblChangeCard;
         private System.Windows.Forms.Label lblTotal;
         private System.Windows.Forms.Label lblCardNameCash;

--- a/MiniPosSystem/Forms/frmReceipt.cs
+++ b/MiniPosSystem/Forms/frmReceipt.cs
@@ -37,11 +37,13 @@ namespace MiniPosSystem.Forms
             }
         }
 
+        /// <summary>
+        /// Populates the order summary list on the receipt form
+        /// </summary>
         private void PopulateOrderInfo()
         {
-            //Populate the listbox with the names of the products
-            //they ordered along with their price
-            throw new NotImplementedException();
+            lstOrderInfo.DataSource = order.Products;
+            lstOrderInfo.DisplayMember = nameof(Products.Name) + nameof(Products.Price);
         }
 
         private void PopulateDateInfo()

--- a/MiniPosSystem/Forms/frmReceipt.cs
+++ b/MiniPosSystem/Forms/frmReceipt.cs
@@ -50,8 +50,8 @@ namespace MiniPosSystem.Forms
         {
             DateTime date = DateTime.Now;
 
-            lblTime.Text = date.Hour + ":" + date.Minute;
-            lblDate.Text = date.Date.ToString();
+            lblTime.Text = date.ToString("hh:mm tt");
+            lblDate.Text = date.ToShortDateString();
         }
 
         private void PopulateCashInfo()


### PR DESCRIPTION
Closes #32 

- Did as instructed in the PopulateOrderInfo() method stub ( just display "name - $price" )
- Card validation accounts for null/white space
- Allow user to enter "-" if so desired when entering card number

Name still needs to be validated. As of now, the name can consist of numbers but not white space 